### PR TITLE
move neuvector mis

### DIFF
--- a/components/cft-neuvector/keyvault.tf
+++ b/components/cft-neuvector/keyvault.tf
@@ -8,7 +8,6 @@ module "azurekeyvault" {
   common_tags                = module.ctags.common_tags
   object_id                  = data.azurerm_client_config.current.object_id
   managed_identity_object_id = data.azurerm_user_assigned_identity.managed_identity.principal_id
-  create_managed_identity    = true
 }
 
 resource "azurerm_key_vault_access_policy" "sc_access_policy" {

--- a/components/cft-neuvector/managed-identity.tf
+++ b/components/cft-neuvector/managed-identity.tf
@@ -1,0 +1,58 @@
+locals {
+
+  managed_identity_subscription_id = {
+    ithc = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    perftest = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    aat = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+    prod = {
+      subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
+    }
+  }
+
+}
+
+provider "azurerm" {
+  subscription_id            = local.managed_identity_subscription_id["${var.env}"].subscription
+  skip_provider_registration = "true"
+  features {}
+  alias = "managed_identity_infra_sub"
+}
+
+resource "azurerm_user_assigned_identity" "managed_identity" {
+
+  provider            = azurerm.managed_identity_infra_sub
+  resource_group_name = "managed-identities-${var.env}-rg"
+  location            = var.location
+
+  name = "${var.product}-${var.env}-mi"
+
+  tags  = module.ctags.common_tags
+}
+
+resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
+  key_vault_id = module.azurekeyvault.key_vault_id
+
+  object_id    = azurerm_user_assigned_identity.managed_identity.principal_id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+
+  key_permissions = [
+    "Get",
+    "List",
+  ]
+
+  certificate_permissions = [
+    "Get",
+    "List",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}

--- a/components/cft-neuvector/managed-identity.tf
+++ b/components/cft-neuvector/managed-identity.tf
@@ -32,14 +32,14 @@ resource "azurerm_user_assigned_identity" "managed_identity" {
 
   name = "${var.product}-${var.env}-mi"
 
-  tags  = module.ctags.common_tags
+  tags = module.ctags.common_tags
 }
 
 resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
   key_vault_id = module.azurekeyvault.key_vault_id
 
-  object_id    = azurerm_user_assigned_identity.managed_identity.principal_id
-  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id = azurerm_user_assigned_identity.managed_identity.principal_id
+  tenant_id = data.azurerm_client_config.current.tenant_id
 
   key_permissions = [
     "Get",

--- a/components/cft-neuvector/managed-identity.tf
+++ b/components/cft-neuvector/managed-identity.tf
@@ -1,5 +1,4 @@
 locals {
-
   managed_identity_subscription_id = {
     ithc = {
       subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
@@ -14,7 +13,6 @@ locals {
       subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
     }
   }
-
 }
 
 provider "azurerm" {
@@ -25,14 +23,11 @@ provider "azurerm" {
 }
 
 resource "azurerm_user_assigned_identity" "managed_identity" {
-
   provider            = azurerm.managed_identity_infra_sub
+  name                = "${var.product}-${var.env}-mi"
   resource_group_name = "managed-identities-${var.env}-rg"
   location            = var.location
-
-  name = "${var.product}-${var.env}-mi"
-
-  tags = module.ctags.common_tags
+  tags                = module.ctags.common_tags
 }
 
 resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {


### PR DESCRIPTION
Removed create_managed_identity as it was was trying to create it in the cftapps sub.
Added MIs separately to avoid recreating kvs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
