### PR TITLE
Access to cftapps keyvault added

### DIFF
--- a/components/cft-neuvector/data.tf
+++ b/components/cft-neuvector/data.tf
@@ -6,6 +6,11 @@ data "azurerm_user_assigned_identity" "managed_identity" {
   resource_group_name = "managed-identities-${var.env}-rg"
 }
 
+data "azurerm_key_vault" "cftapps_key_vault" {
+  name                = local.cftapps_keyvault["${var.env}"].name
+  resource_group_name = local.cftapps_keyvault["${var.env}"].rg
+}
+
 data "azuread_group" "platops_sc" {
   display_name     = "DTS Platform Operations SC"
   security_enabled = true

--- a/components/cft-neuvector/locals.tf
+++ b/components/cft-neuvector/locals.tf
@@ -1,3 +1,36 @@
 locals {
   storage_account_repl_type = var.env == "stg" || var.env == "ithc" || var.env == "prod" ? "ZRS" : "LRS"
+
+  managed_identity_subscription_id = {
+    ithc = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    perftest = {
+      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
+    }
+    aat = {
+      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+    }
+    prod = {
+      subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
+    }
+  }
+  cftapps_keyvault = {
+    ithc = {
+      name = "cftapps-ithc"
+      rg   = "core-infra-ithc-rg"
+    }
+    perftest = {
+      name = "cftapps-test"
+      rg   = "core-infra-test-rg"
+    }
+    aat = {
+      name = "cftapps-stg"
+      rg   = "core-infra-stg-rg"
+    }
+    prod = {
+      name = "cft-apps-prod"
+      rg   = "core-infra-prod-rg"
+    }
+  }
 }

--- a/components/cft-neuvector/managed-identity.tf
+++ b/components/cft-neuvector/managed-identity.tf
@@ -1,20 +1,3 @@
-locals {
-  managed_identity_subscription_id = {
-    ithc = {
-      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
-    }
-    perftest = {
-      subscription = "7a4e3bd5-ae3a-4d0c-b441-2188fee3ff1c"
-    }
-    aat = {
-      subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
-    }
-    prod = {
-      subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
-    }
-  }
-}
-
 provider "azurerm" {
   subscription_id            = local.managed_identity_subscription_id["${var.env}"].subscription
   skip_provider_registration = "true"
@@ -32,6 +15,28 @@ resource "azurerm_user_assigned_identity" "managed_identity" {
 
 resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
   key_vault_id = module.azurekeyvault.key_vault_id
+
+  object_id = azurerm_user_assigned_identity.managed_identity.principal_id
+  tenant_id = data.azurerm_client_config.current.tenant_id
+
+  key_permissions = [
+    "Get",
+    "List",
+  ]
+
+  certificate_permissions = [
+    "Get",
+    "List",
+  ]
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+}
+
+resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
+  key_vault_id = data.azurerm_key_vault.cftapps_key_vault.id
 
   object_id = azurerm_user_assigned_identity.managed_identity.principal_id
   tenant_id = data.azurerm_client_config.current.tenant_id

--- a/components/cft-neuvector/managed-identity.tf
+++ b/components/cft-neuvector/managed-identity.tf
@@ -35,7 +35,7 @@ resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
   ]
 }
 
-resource "azurerm_key_vault_access_policy" "managed_identity_access_policy" {
+resource "azurerm_key_vault_access_policy" "cftapps_kv_access_policy" {
   key_vault_id = data.azurerm_key_vault.cftapps_key_vault.id
 
   object_id = azurerm_user_assigned_identity.managed_identity.principal_id


### PR DESCRIPTION
Some differences in how these keyvaults are named (cft-apps vs cftapps so have put into locals to handle that issue), and some differing env names.
restapi-config pods need access to another keyvault (cftapps ones).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
