### PR TITLE
DTSPO-15523: Add PTL pipeline step

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -49,6 +49,11 @@ parameters:
         component: cft-neuvector
         service_connection: DCD-CFTAPPS-STG
       - deployment: 'neuvector'
+        environment: 'ptl'
+        dependsOn: 'Precheck'
+        component: cft-neuvector
+        service_connection: DTS-CFTPTL-INTSVC
+      - deployment: 'neuvector'
         environment: 'prod'
         dependsOn: 'Precheck'
         component: cft-neuvector
@@ -58,9 +63,6 @@ parameters:
     displayName: Location
     type: string
     default: 'UK South'
-    values:
-      - 'UK South'
-      - 'UK West'
 
 variables:
   terraformInitSubscription: 04d27a32-7a07-48b3-95b8-3c8691e1a263

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,8 +1,3 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
-
 resources:
   repositories:
   - repository: cnp-azuredevops-libraries
@@ -126,6 +121,10 @@ stages:
                 ${{ if eq(parameter.environment, 'ithc') }}:
                   initCommandOptions:
                   planCommandOptions: ${{ variables.globalTfCommandOptions }}
+                  destroyCommandOptions: ${{ variables.globalTfCommandOptions }}
+                ${{ if eq(parameter.environment, 'prod') }}:
+                  initCommandOptions:
+                  planCommandOptions: ${{ variables.globalTfCommandOptions }} -target azurerm_user_assigned_identity.managed_identity
                   destroyCommandOptions: ${{ variables.globalTfCommandOptions }}
                 ${{ if eq(parameter.environment, 'prod') }}:
                   initCommandOptions:

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -122,7 +122,7 @@ stages:
                   initCommandOptions:
                   planCommandOptions: ${{ variables.globalTfCommandOptions }}
                   destroyCommandOptions: ${{ variables.globalTfCommandOptions }}
-                ${{ if eq(parameter.environment, 'prod') }}:
+                ${{ if eq(parameter.environment, 'ptl') }}:
                   initCommandOptions:
                   planCommandOptions: ${{ variables.globalTfCommandOptions }} -target azurerm_user_assigned_identity.managed_identity
                   destroyCommandOptions: ${{ variables.globalTfCommandOptions }}

--- a/components/cft-neuvector/locals.tf
+++ b/components/cft-neuvector/locals.tf
@@ -14,6 +14,9 @@ locals {
     aat = {
       subscription = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
     }
+    ptl = {
+      subscription = "1baf5470-1c3e-40d3-a6f7-74bfbce4b348"
+    }
     prod = {
       subscription = "8999dec3-0104-4a27-94ee-6588559729d1"
     }
@@ -34,6 +37,10 @@ locals {
     aat = {
       name = "cftapps-stg"
       rg   = "core-infra-stg-rg"
+    }
+    ptl = {
+      name = "cftptl-intsvc"
+      rg   = "core-infra-intsvc-rg"
     }
     prod = {
       name = "cft-apps-prod"

--- a/components/cft-neuvector/managed-identity.tf
+++ b/components/cft-neuvector/managed-identity.tf
@@ -6,7 +6,7 @@ provider "azurerm" {
 }
 
 locals {
-  env = var.env == "sbox" ? "sandbox" : var.env || var.env == "ptl" ? "cftptl-intsvc" : var.env
+  env = var.env == "sbox" ? "sandbox" : var.env == "ptl" ? "cftptl-intsvc" : var.env
 }
 
 resource "azurerm_user_assigned_identity" "managed_identity" {

--- a/components/cft-neuvector/managed-identity.tf
+++ b/components/cft-neuvector/managed-identity.tf
@@ -6,7 +6,7 @@ provider "azurerm" {
 }
 
 locals {
-  env = var.env == "sbox" ? "sandbox" : var.env
+  env = var.env == "sbox" ? "sandbox" : var.env || var.env == "ptl" ? "cftptl-intsvc" : var.env
 }
 
 resource "azurerm_user_assigned_identity" "managed_identity" {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15523

This change:
  - Adds pre-req config for a new ptl instance of neuvector where we intend to host a central console as per ^
  - Targets only the MI for now due to the following error in the key vault module otherwise
   ```
│   37:   for_each = local.managed_identity_list
│     ├────────────────
│     │ local.managed_identity_list is a set of dynamic, known only after apply
│ 
│ The "for_each" set includes values derived from resource attributes that
│ cannot be determined until apply, and so Terraform cannot determine the
│ full set of keys that will identify the instances of this resource.
```

Targeting will be removed after this and a resource ID for the MI is available

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
